### PR TITLE
All paths now call done with either success or with an error if one was generated

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function(options) {
 
   var import_paths
     , import_paths_len;
-  
+
   return function(url, prev, done) {
     if (url.slice(0, 4) !== 'CSS:') {
       return done();
@@ -30,11 +30,14 @@ module.exports = function(options) {
       css_filepath = path.join(import_path, css_path);
       if (fs.existsSync(css_filepath)) {
         fs.readFile(css_filepath, function(err, data) {
-          if (err) return console.error(err);
+          if (err) {
+            return done(err);
+          }
           done({contents: data.toString()});
         });
-        break;
+        return;
       }
     }
+    return done(new Error('Specified CSS file not found! ("' + css_path + '" referenced from "' + prev + '")'));
   };
 };

--- a/test/badsource.scss
+++ b/test/badsource.scss
@@ -1,0 +1,5 @@
+html {
+  font-size: 10px;
+}
+
+@import "CSS:doesntexist";

--- a/test/test.js
+++ b/test/test.js
@@ -26,3 +26,11 @@ node.render({
     assert.equal(actual.css.toString(), expected.toString());
   });
 });
+
+node.render({
+  file: path.join(__dirname, 'badsource.scss'),
+  importer: cssImporter({import_paths: [__dirname]})
+}, function(err, actual) {
+  assert.notEqual(err, null);
+  assert.equal(err.message.slice(0, 29), 'Specified CSS file not found!');
+});


### PR DESCRIPTION
Right now there are two conditions that result in no error getting returned to sass:
- If the to-be-included file was never found in the search paths
- If the file-read failed for some reason such as permissions

As a result, sass must assume that there is an asynchronous process running and waits forever without ever providing feedback as to what when wrong.
