### PR TITLE
Allow using direct url for the css path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - "0.12"
-  - "0.11"
   - "0.10"
-  - "iojs"
-  - "iojs-v1.0.4"
+  - "4"
+  - "5"

--- a/index.js
+++ b/index.js
@@ -29,15 +29,23 @@ module.exports = function(options) {
       import_path = import_paths[i];
       css_filepath = path.join(import_path, css_path);
       if (fs.existsSync(css_filepath)) {
-        fs.readFile(css_filepath, function(err, data) {
-          if (err) {
-            return done(err);
-          }
-          done({contents: data.toString()});
-        });
-        return;
+        return readPath(css_filepath, done);
+      } else {
+        css_filepath = path.join(import_path, url.slice(4));
+        if (fs.existsSync(css_filepath)) {
+          return readPath(css_filepath, done);
+        }
       }
     }
     return done(new Error('Specified CSS file not found! ("' + css_path + '" referenced from "' + prev + '")'));
   };
 };
+
+function readPath(css_filepath, done) {
+  fs.readFile(css_filepath, function(err, data) {
+    if (err) {
+      return done(err);
+    }
+    done({contents: data.toString()});
+  });
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "css importer for node-sass",
   "main": "index.js",
   "scripts": {
-    "test": "node test/test.js"
+    "test": "tap test/test.js"
   },
   "repository": {
     "type": "git",
@@ -23,6 +23,8 @@
   },
   "homepage": "https://github.com/fetch/node-sass-css-importer",
   "devDependencies": {
-    "node-sass": "^3.3.2"
+    "node-sass": "^3.3.2",
+    "tap": "^5.0.0",
+    "tape": "^4.4.0"
   }
 }

--- a/test/anothercss.txt
+++ b/test/anothercss.txt
@@ -1,0 +1,3 @@
+body {
+  padding: 10px;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -35,7 +35,7 @@ tape('can import CSS files correctly from data', function(t) {
   });
 });
 
-tape('handles non existent files', function(t) {
+tape('handles non existent files from file', function(t) {
   t.plan(2);
 
   node.render({
@@ -47,10 +47,29 @@ tape('handles non existent files', function(t) {
   });
 });
 
-node.render({
-  data: 'html{font-size: 10px}@import "CSS:doesntexist";',
-  importer: cssImporter({import_paths: [__dirname]})
-}, function(err, actual) {
-  assert.notEqual(err, null);
-  assert.equal(err.message.slice(0, 29), 'Specified CSS file not found!');
+tape('handles non existent files from data', function(t) {
+  t.plan(2);
+
+  node.render({
+    data: 'html{font-size: 10px}@import "CSS:doesntexist";',
+    importer: cssImporter({import_paths: [__dirname]})
+  }, function(err, actual) {
+    t.notEqual(err, null);
+    t.equal(err.message.slice(0, 29), 'Specified CSS file not found!');
+  });
+});
+
+tape('can inline css content that with a different name', function(t) {
+  t.plan(3);
+
+  node.render({
+    data: 'html{font-size: 10px}@import "CSS:anothercss.txt";',
+    importer: cssImporter({import_paths: [__dirname]})
+  }, function(err, actual) {
+    t.equal(err, null);
+    fs.readFile(path.join(__dirname, 'expected.css'), function(err, expected) {
+      t.equal(err, null);
+      t.equal(actual.css.toString(), expected.toString());
+    });
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,38 +1,50 @@
 var fs = require('fs')
   , path = require('path')
-  , assert = require('assert');
+  , tape = require('tape');
 
 var node = require('node-sass')
   , cssImporter = require('../');
 
-node.render({
-  file: path.join(__dirname, 'source.scss'),
-  importer: cssImporter({import_paths: [path.join(__dirname, 'precedence')]})
-}, function(err, actual) {
-  assert.equal(err, null);
-  fs.readFile(path.join(__dirname, 'expected.css'), function(err, expected) {
-    assert.equal(err, null);
-    assert.equal(actual.css.toString(), expected.toString());
+tape('imports CSS files correctly from file', function(t) {
+  t.plan(3);
+
+  node.render({
+    file: path.join(__dirname, 'source.scss'),
+    importer: cssImporter({import_paths: [path.join(__dirname, 'precedence')]})
+  }, function(err, actual) {
+    t.equal(err, null);
+    fs.readFile(path.join(__dirname, 'expected.css'), function(err, expected) {
+      t.equal(err, null);
+      t.equal(actual.css.toString(), expected.toString());
+    });
   });
 });
 
-node.render({
-  data: 'html{font-size: 10px}@import "CSS:body";',
-  importer: cssImporter({import_paths: [__dirname]})
-}, function(err, actual) {
-  assert.equal(err, null);
-  fs.readFile(path.join(__dirname, 'expected.css'), function(err, expected) {
-    assert.equal(err, null);
-    assert.equal(actual.css.toString(), expected.toString());
+tape('can import CSS files correctly from data', function(t) {
+  t.plan(3);
+
+  node.render({
+    data: 'html{font-size: 10px}@import "CSS:body";',
+    importer: cssImporter({import_paths: [__dirname]})
+  }, function(err, actual) {
+    t.equal(err, null);
+    fs.readFile(path.join(__dirname, 'expected.css'), function(err, expected) {
+      t.equal(err, null);
+      t.equal(actual.css.toString(), expected.toString());
+    });
   });
 });
 
-node.render({
-  file: path.join(__dirname, 'badsource.scss'),
-  importer: cssImporter({import_paths: [__dirname]})
-}, function(err, actual) {
-  assert.notEqual(err, null);
-  assert.equal(err.message.slice(0, 29), 'Specified CSS file not found!');
+tape('handles non existent files', function(t) {
+  t.plan(2);
+
+  node.render({
+    file: path.join(__dirname, 'badsource.scss'),
+    importer: cssImporter({import_paths: [__dirname]})
+  }, function(err, actual) {
+    t.notEqual(err, null);
+    t.equal(err.message.slice(0, 29), 'Specified CSS file not found!');
+  });
 });
 
 node.render({


### PR DESCRIPTION
- Allow using direct url for the css path

For example, you can now use `CSS:anothercss.txt` and it'll inline it.
Sass may still fail to compile if it isn't a css file.
It first checks to see if `anothercss.txt.css` exists and otherwise will
fall back to `anothercss.txt`.
- Switch to using tape for testing and assertion

This is because in the old way, if an error existed, the process
wouldn't exit correctly. Now tape takes care of handling breakdown for
us.
Also, use tap for prettier test output.
- add sudo:false to travis.yml for faster tests
